### PR TITLE
Fix lint issues in messaging views

### DIFF
--- a/src/app/messages/[chatId]/page.tsx
+++ b/src/app/messages/[chatId]/page.tsx
@@ -44,27 +44,13 @@ export default function ChatScreen({ params }: Params) {
     el.scrollTop = el.scrollHeight;
   }, [messages]);
 
+  const grouped = useMemo(() => groupByDay(messages), [messages]);
+
   if (!chat) return (
     <AppLayout>
       <div className="max-w-2xl mx-auto px-4 py-10 text-gray-300">Chat not found.</div>
     </AppLayout>
   );
-
-  const grouped = useMemo(() => groupByDay(messages), [messages]);
-
-  const handleSend = (text: string) => {
-    const newMsg: Message = {
-      id: `m_${Date.now()}`,
-      chatId: chatId,
-      senderId: 'me',
-      type: 'text',
-      text,
-      createdAt: new Date().toISOString(),
-      status: 'sent'
-    };
-    setMessages(prev => [...prev, newMsg]);
-    setDrafts(prev => ({ ...prev, [chatId]: '' }));
-  };
 
   const draft = drafts[chatId] ?? '';
 

--- a/src/components/messaging/ChatList.tsx
+++ b/src/components/messaging/ChatList.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { Eye } from "lucide-react";
 import ChatListItem from "./ChatListItem";
@@ -162,20 +161,6 @@ const ChatList = ({ normalChats, anonymousChats }: ChatListProps) => {
     const anons = items.anons;
     return { normals, anons };
   }, [items]);
-
-  const handleToggle = (id: string, key: "pinned" | "muted") => {
-    setItems((prev) => ({
-      ...prev,
-      normals: prev.normals.map((c) => (c.id === id ? { ...c, [key]: !c[key] } : c)),
-    }));
-  };
-
-  const handleDelete = (id: string) => {
-    setItems((prev) => ({
-      normals: prev.normals.filter((c) => c.id !== id),
-      anons: prev.anons.filter((c) => c.id !== id),
-    }));
-  };
 
   return (
     <div className="pb-24" style={{ fontFamily: "var(--font-inter)" }}>


### PR DESCRIPTION
## Summary
- ensure the chat message grouping memo runs unconditionally to satisfy the hooks linter
- remove unused handlers and an unused import from the chat list module

## Testing
- `npm run build` *(fails: cannot download Google-hosted fonts in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cae49a00948329886b144d734740b2