### PR TITLE
Refine Supabase auth context typing and clean lint warnings

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -7,7 +7,7 @@ export async function GET(request: NextRequest) {
 
   if (code) {
     try {
-      const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+      const { error } = await supabase.auth.exchangeCodeForSession(code);
       
       if (error) {
         console.error('Error exchanging code for session:', error);

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -18,8 +18,8 @@ export default function SignInPage() {
   const continueWithGoogle = async () => {
     try {
       setLoading(true);
-      const { data, error } = await signInWithGoogle();
-      
+      const { error } = await signInWithGoogle();
+
       if (error) {
         console.error('Google sign-in error:', error);
         alert('Failed to sign in with Google. Please try again.');
@@ -38,8 +38,8 @@ export default function SignInPage() {
   const continueWithEmail = async () => {
     try {
       setLoading(true);
-      const { data, error } = await signInWithOtp(email.trim());
-      
+      const { error } = await signInWithOtp(email.trim());
+
       if (error) {
         console.error('OTP request error:', error);
         alert(error.message || 'Failed to send verification code. Please try again.');

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -20,8 +20,8 @@ export default function SignUpPage() {
     
     try {
       setLoading(true);
-      const { data, error } = await signInWithGoogle();
-      
+      const { error } = await signInWithGoogle();
+
       if (error) {
         console.error('Google sign-up error:', error);
         alert('Failed to sign up with Google. Please try again.');
@@ -42,8 +42,8 @@ export default function SignUpPage() {
     
     try {
       setLoading(true);
-      const { data, error } = await signInWithOtp(email.trim());
-      
+      const { error } = await signInWithOtp(email.trim());
+
       if (error) {
         console.error('OTP request error:', error);
         alert(error.message || 'Failed to send verification code. Please try again.');

--- a/src/app/auth/verify-otp/page.tsx
+++ b/src/app/auth/verify-otp/page.tsx
@@ -102,7 +102,7 @@ function VerifyOtpContent() {
       setError(null);
       setStatus(null);
 
-      const { data, error: verifyError } = await verifyOtp(email, code);
+      const { error: verifyError } = await verifyOtp(email, code);
 
       if (verifyError) {
         console.error('OTP verification error:', verifyError);
@@ -131,7 +131,7 @@ function VerifyOtpContent() {
       setStatus('Sending a fresh code to your inbox...');
       setCode('');
 
-      const { data, error: resendError } = await signInWithOtp(email);
+      const { error: resendError } = await signInWithOtp(email);
 
       if (resendError) {
         console.error('OTP resend error:', resendError);

--- a/src/app/edit-profile/page.tsx
+++ b/src/app/edit-profile/page.tsx
@@ -26,13 +26,6 @@ const EditProfilePage = () => {
     linkedin: ''
   });
 
-  // Social validation state
-  const [socialValidation, setSocialValidation] = useState({
-    instagram: { isValid: true, message: '' },
-    twitter: { isValid: true, message: '' }, // Will be renamed to 'x' in UI
-    linkedin: { isValid: true, message: '' }
-  });
-
   // Modal states for editing social links
   const [modalStates, setModalStates] = useState({
     instagram: false,
@@ -42,7 +35,6 @@ const EditProfilePage = () => {
 
   // Temporary input state for modal editing
   const [tempSocialInput, setTempSocialInput] = useState('');
-  const [currentEditingPlatform, setCurrentEditingPlatform] = useState<'instagram' | 'x' | 'linkedin' | null>(null);
 
   // State for form errors
   const [errors, setErrors] = useState<{
@@ -61,81 +53,13 @@ const EditProfilePage = () => {
   // Animation flags for modals
   const [bannerAnim, setBannerAnim] = useState(false);
   const [profileAnim, setProfileAnim] = useState(false);
-  
-  // Overlays should be visible permanently on all devices
-  const showOverlays = true;
-  
+
   // File input refs
   const profileFileInputRef = useRef<HTMLInputElement>(null);
   const bannerFileInputRef = useRef<HTMLInputElement>(null);
 
   const handleBack = () => {
     router.push('/profile');
-  };
-
-  // Regex validation functions for social links
-  const validateInstagram = (url: string): { isValid: boolean; message: string } => {
-    if (!url.trim()) return { isValid: true, message: '' };
-    
-    const instagramRegex = /^(https?:\/\/)?(www\.)?instagram\.com\/[a-zA-Z0-9._]+\/?$/;
-    
-    if (!instagramRegex.test(url)) {
-      return { 
-        isValid: false, 
-        message: 'Please enter a valid Instagram URL (e.g., instagram.com/username)' 
-      };
-    }
-    return { isValid: true, message: '' };
-  };
-
-  const validateTwitter = (url: string): { isValid: boolean; message: string } => {
-    if (!url.trim()) return { isValid: true, message: '' };
-    
-    const twitterRegex = /^(https?:\/\/)?(www\.)?(twitter\.com|x\.com)\/[a-zA-Z0-9_]+\/?$/;
-    
-    if (!twitterRegex.test(url)) {
-      return { 
-        isValid: false, 
-        message: 'Please enter a valid Twitter/X URL (e.g., x.com/username or twitter.com/username)' 
-      };
-    }
-    return { isValid: true, message: '' };
-  };
-
-  const validateLinkedIn = (url: string): { isValid: boolean; message: string } => {
-    if (!url.trim()) return { isValid: true, message: '' };
-    
-    const linkedinRegex = /^(https?:\/\/)?(www\.)?linkedin\.com\/(in|company)\/[a-zA-Z0-9-]+\/?$/;
-    
-    if (!linkedinRegex.test(url)) {
-      return { 
-        isValid: false, 
-        message: 'Please enter a valid LinkedIn URL (e.g., linkedin.com/in/username)' 
-      };
-    }
-    return { isValid: true, message: '' };
-  };
-
-  // Handle social link changes with validation
-  const handleSocialLinkChange = (platform: keyof typeof socialLinks, value: string) => {
-    setSocialLinks(prev => ({ ...prev, [platform]: value }));
-    
-    let validation;
-    switch (platform) {
-      case 'instagram':
-        validation = validateInstagram(value);
-        break;
-      case 'twitter':
-        validation = validateTwitter(value);
-        break;
-      case 'linkedin':
-        validation = validateLinkedIn(value);
-        break;
-      default:
-        validation = { isValid: true, message: '' };
-    }
-    
-    setSocialValidation(prev => ({ ...prev, [platform]: validation }));
   };
 
   // Ensure only one menu is open at a time
@@ -525,7 +449,6 @@ const EditProfilePage = () => {
                       onClick={(e) => {
                         e.preventDefault();
                         setIsSubmitting(false);
-                        setCurrentEditingPlatform('instagram');
                         setTempSocialInput(socialLinks.instagram);
                         setModalStates(prev => ({ ...prev, instagram: true }));
                       }}
@@ -569,7 +492,6 @@ const EditProfilePage = () => {
                       onClick={(e) => {
                         e.preventDefault();
                         setIsSubmitting(false);
-                        setCurrentEditingPlatform('x');
                         setTempSocialInput(socialLinks.twitter);
                         setModalStates(prev => ({ ...prev, x: true }));
                       }}
@@ -613,7 +535,6 @@ const EditProfilePage = () => {
                       onClick={(e) => {
                         e.preventDefault();
                         setIsSubmitting(false);
-                        setCurrentEditingPlatform('linkedin');
                         setTempSocialInput(socialLinks.linkedin);
                         setModalStates(prev => ({ ...prev, linkedin: true }));
                       }}

--- a/src/app/feedback/page.tsx
+++ b/src/app/feedback/page.tsx
@@ -4,12 +4,12 @@ import { useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import AppLayout from '@/components/AppLayout';
 import AppHeader from '@/components/AppHeader';
-import { ArrowLeft, Upload, X, Check, Paperclip } from 'lucide-react';
+import { ArrowLeft, X, Check, Paperclip } from 'lucide-react';
+import Image from 'next/image';
 
 const FeedbackPage = () => {
   const router = useRouter();
   const [feedbackText, setFeedbackText] = useState('');
-  const [selectedImage, setSelectedImage] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
@@ -31,7 +31,6 @@ const FeedbackPage = () => {
         return;
       }
 
-      setSelectedImage(file);
       const reader = new FileReader();
       reader.onload = (e) => {
         setImagePreview(e.target?.result as string);
@@ -41,7 +40,6 @@ const FeedbackPage = () => {
   };
 
   const removeImage = () => {
-    setSelectedImage(null);
     setImagePreview(null);
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
@@ -80,7 +78,6 @@ const FeedbackPage = () => {
       // Reset form after success
       setTimeout(() => {
         setFeedbackText('');
-        setSelectedImage(null);
         setImagePreview(null);
         setShowSuccess(false);
         if (fileInputRef.current) {
@@ -136,10 +133,13 @@ const FeedbackPage = () => {
             {/* Image Preview */}
             {imagePreview && (
               <div className="relative">
-                <img
+                <Image
                   src={imagePreview}
                   alt="Preview"
+                  width={800}
+                  height={450}
                   className="w-full max-h-64 object-cover rounded-xl border-2 border-white"
+                  unoptimized
                 />
                 <button
                   type="button"

--- a/src/app/onboarding/profile/social/page.tsx
+++ b/src/app/onboarding/profile/social/page.tsx
@@ -25,13 +25,6 @@ export default function CompleteProfileOnboardingPage() {
     linkedin: '',
   });
 
-  // Social validation state
-  const [socialValidation, setSocialValidation] = useState({
-    instagram: { isValid: true, message: '' },
-    twitter: { isValid: true, message: '' },
-    linkedin: { isValid: true, message: '' },
-  });
-
   // Modal states for editing social links
   const [modalStates, setModalStates] = useState({
     instagram: false,
@@ -41,7 +34,6 @@ export default function CompleteProfileOnboardingPage() {
 
   // Temporary input state for modal editing
   const [tempSocialInput, setTempSocialInput] = useState('');
-  const [currentEditingPlatform, setCurrentEditingPlatform] = useState<'instagram' | 'x' | 'linkedin' | null>(null);
 
   // State for form errors (bio only here)
   const [errors, setErrors] = useState<{ bio: string }>({ bio: '' });
@@ -57,51 +49,6 @@ export default function CompleteProfileOnboardingPage() {
   // File input refs
   const profileFileInputRef = useRef<HTMLInputElement>(null);
   const bannerFileInputRef = useRef<HTMLInputElement>(null);
-
-  // Regex validation functions for social links (reused)
-  const validateInstagram = (url: string): { isValid: boolean; message: string } => {
-    if (!url.trim()) return { isValid: true, message: '' };
-    const instagramRegex = /^(https?:\/\/)?(www\.)?instagram\.com\/[a-zA-Z0-9._]+\/?$/;
-    if (!instagramRegex.test(url)) {
-      return { isValid: false, message: 'Please enter a valid Instagram URL (e.g., instagram.com/username)' };
-    }
-    return { isValid: true, message: '' };
-  };
-
-  const validateTwitter = (url: string): { isValid: boolean; message: string } => {
-    if (!url.trim()) return { isValid: true, message: '' };
-    const twitterRegex = /^(https?:\/\/)?(www\.)?(twitter\.com|x\.com)\/[a-zA-Z0-9_]+\/?$/;
-    if (!twitterRegex.test(url)) {
-      return { isValid: false, message: 'Please enter a valid Twitter/X URL (e.g., x.com/username or twitter.com/username)' };
-    }
-    return { isValid: true, message: '' };
-  };
-
-  const validateLinkedIn = (url: string): { isValid: boolean; message: string } => {
-    if (!url.trim()) return { isValid: true, message: '' };
-    const linkedinRegex = /^(https?:\/\/)?(www\.)?linkedin\.com\/(in|company)\/[a-zA-Z0-9-]+\/?$/;
-    if (!linkedinRegex.test(url)) {
-      return { isValid: false, message: 'Please enter a valid LinkedIn URL (e.g., linkedin.com/in/username)' };
-    }
-    return { isValid: true, message: '' };
-  };
-
-  // Handle social link changes with validation
-  const handleSocialLinkChange = (platform: keyof typeof socialLinks, value: string) => {
-    setSocialLinks(prev => ({ ...prev, [platform]: value }));
-    let validation;
-    switch (platform) {
-      case 'instagram':
-        validation = validateInstagram(value); break;
-      case 'twitter':
-        validation = validateTwitter(value); break;
-      case 'linkedin':
-        validation = validateLinkedIn(value); break;
-      default:
-        validation = { isValid: true, message: '' };
-    }
-    setSocialValidation(prev => ({ ...prev, [platform]: validation }));
-  };
 
   // Ensure only one menu is open at a time
   useEffect(() => { if (showBannerMenu) setShowProfileMenu(false); }, [showBannerMenu]);
@@ -368,7 +315,12 @@ export default function CompleteProfileOnboardingPage() {
                     </div>
                     <button
                       type="button"
-                      onClick={(e) => { e.preventDefault(); setIsSubmitting(false); setCurrentEditingPlatform('instagram'); setTempSocialInput(socialLinks.instagram); setModalStates(prev => ({ ...prev, instagram: true })); }}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setIsSubmitting(false);
+                      setTempSocialInput(socialLinks.instagram);
+                      setModalStates(prev => ({ ...prev, instagram: true }));
+                    }}
                       className="px-4 py-2 bg-gray-800 hover:bg-gray-700 text-white rounded-lg transition-colors font-medium flex items-center gap-2"
                       style={{ fontFamily: 'var(--font-inter)' }}
                     >
@@ -397,7 +349,12 @@ export default function CompleteProfileOnboardingPage() {
                     </div>
                     <button
                       type="button"
-                      onClick={(e) => { e.preventDefault(); setIsSubmitting(false); setCurrentEditingPlatform('x'); setTempSocialInput(socialLinks.twitter); setModalStates(prev => ({ ...prev, x: true })); }}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setIsSubmitting(false);
+                      setTempSocialInput(socialLinks.twitter);
+                      setModalStates(prev => ({ ...prev, x: true }));
+                    }}
                       className="px-4 py-2 bg-gray-800 hover:bg-gray-700 text-white rounded-lg transition-colors font-medium flex items-center gap-2"
                       style={{ fontFamily: 'var(--font-inter)' }}
                     >
@@ -426,7 +383,12 @@ export default function CompleteProfileOnboardingPage() {
                     </div>
                     <button
                       type="button"
-                      onClick={(e) => { e.preventDefault(); setIsSubmitting(false); setCurrentEditingPlatform('linkedin'); setTempSocialInput(socialLinks.linkedin); setModalStates(prev => ({ ...prev, linkedin: true })); }}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setIsSubmitting(false);
+                      setTempSocialInput(socialLinks.linkedin);
+                      setModalStates(prev => ({ ...prev, linkedin: true }));
+                    }}
                       className="px-4 py-2 bg-gray-800 hover:bg-gray-700 text-white rounded-lg transition-colors font-medium flex items-center gap-2"
                       style={{ fontFamily: 'var(--font-inter)' }}
                     >

--- a/src/app/radar/page.tsx
+++ b/src/app/radar/page.tsx
@@ -6,18 +6,7 @@ import AppHeader from '@/components/AppHeader';
 import SocialProfileCard from '@/components/SocialProfileCard';
 import VisibilityControl from '@/components/VisibilityControl';
 import { useVisibility } from '@/contexts/VisibilityContext';
-import type { SocialLinks } from '@/constants/socialPlatforms';
 import { NEARBY_USERS } from '@/constants/nearbyUsers';
-
-interface NearbyUser {
-  id: string;
-  name: string;
-  username: string;
-  profilePhoto: string;
-  bio: string;
-  distance: string;
-  socialLinks: SocialLinks;
-}
 
 const RadarScreen = () => {
   const [searchOpen, setSearchOpen] = useState(false);

--- a/src/components/messaging/ChatHeader.tsx
+++ b/src/components/messaging/ChatHeader.tsx
@@ -11,7 +11,8 @@ interface ChatHeaderProps {
   anonymous?: boolean;
 }
 
-const ChatHeader = ({ title, subtitle, avatarUrl, anonymous }: ChatHeaderProps) => {
+const ChatHeader = ({ title, subtitle, avatarUrl, anonymous: _anonymous }: ChatHeaderProps) => {
+  void _anonymous;
   return (
     <div className="sticky top-0 z-50 bg-black/80 backdrop-blur supports-[backdrop-filter]:bg-black/60 border-b border-slate-800">
       <div className="max-w-2xl mx-auto px-4">

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,130 +1,200 @@
 'use client';
 
-import React, { createContext, useContext, useEffect, useState } from 'react';
-import { User, Session } from '@supabase/supabase-js';
-import { auth, supabase } from '@/utils/supabase';
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import type {
+  AuthChangeEvent,
+  AuthError,
+  AuthOtpResponse,
+  AuthResponse,
+  OAuthResponse,
+  Session,
+  User
+} from '@supabase/supabase-js';
+import { supabase } from '@/utils/supabase';
+import type { Tables } from '@/utils/supabase';
 
-interface AuthContextType {
+type ProfileRow = Tables['profiles'];
+
+type AuthContextValue = {
   user: User | null;
   session: Session | null;
   loading: boolean;
-  signUp: (email: string, password: string, userData?: { full_name?: string; username?: string }) => Promise<{ data: any; error: any }>;
-  signIn: (email: string, password: string) => Promise<{ data: any; error: any }>;
-  signInWithOtp: (email: string) => Promise<{ data: any; error: any }>;
-  verifyOtp: (email: string, token: string, type?: 'signup' | 'email') => Promise<{ data: any; error: any }>;
-  signInWithGoogle: () => Promise<{ data: any; error: any }>;
-  signOut: () => Promise<{ error: any }>;
-}
-
-const AuthContext = createContext<AuthContextType | undefined>(undefined);
-
-export const useAuth = () => {
-  const context = useContext(AuthContext);
-  if (context === undefined) {
-    throw new Error('useAuth must be used within an AuthProvider');
-  }
-  return context;
+  signUp: (
+    email: string,
+    password: string,
+    userData?: { full_name?: string; username?: string }
+  ) => Promise<AuthResponse>;
+  signIn: (email: string, password: string) => Promise<AuthResponse>;
+  signInWithOtp: (email: string) => Promise<AuthOtpResponse>;
+  verifyOtp: (
+    email: string,
+    token: string,
+    type?: 'signup' | 'email'
+  ) => Promise<AuthResponse>;
+  signInWithGoogle: () => Promise<OAuthResponse>;
+  signOut: () => Promise<{ error: AuthError | null }>;
 };
 
-export const useUser = () => {
-  const { user } = useAuth();
-  return user;
-};
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
-interface AuthProviderProps {
-  children: React.ReactNode;
-}
-
-export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
+export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // Get initial session
-    const getInitialSession = async () => {
-      const { data: { session } } = await auth.getSession();
-      setSession(session);
-      setUser(session?.user ?? null);
-      setLoading(false);
-    };
+    let active = true;
 
-    getInitialSession();
-
-    // Listen for auth changes
-    const { data: { subscription } } = auth.onAuthStateChange(async (event, session) => {
-      setSession(session);
-      setUser(session?.user ?? null);
-      setLoading(false);
-
-      // Create or update profile when user signs up or signs in
-      if (event === 'SIGNED_IN' && session?.user) {
-        await createOrUpdateProfile(session.user);
+    (async () => {
+      const { data, error } = await supabase.auth.getSession();
+      if (!active) {
+        return;
       }
-    });
 
-    return () => subscription.unsubscribe();
+      if (error) {
+        console.error('Error fetching initial session:', error);
+        setLoading(false);
+        return;
+      }
+
+      setSession(data.session ?? null);
+      setUser(data.session?.user ?? null);
+      setLoading(false);
+    })();
+
+    const { data: listener } = supabase.auth.onAuthStateChange(
+      (event: AuthChangeEvent, newSession) => {
+        setSession(newSession);
+        setUser(newSession?.user ?? null);
+        setLoading(false);
+
+        if (event === 'SIGNED_IN' && newSession?.user) {
+          void createOrUpdateProfile(newSession.user);
+        }
+      }
+    );
+
+    return () => {
+      active = false;
+      listener?.subscription.unsubscribe();
+    };
   }, []);
 
-  // Create or update user profile in the profiles table
-  const createOrUpdateProfile = async (user: User) => {
+  const createOrUpdateProfile = async (authUser: User) => {
     try {
-      const { data: existingProfile } = await supabase
+      const { data: profileData, error } = await supabase
         .from('profiles')
         .select('*')
-        .eq('id', user.id)
-        .single();
+        .eq('id', authUser.id)
+        .maybeSingle();
+
+      const existingProfile = profileData as ProfileRow | null;
+
+      if (error) {
+        console.error('Error loading profile:', error);
+        return;
+      }
 
       if (!existingProfile) {
-        // Create new profile
-        const { error } = await supabase
-          .from('profiles')
-          .insert({
-            id: user.id,
-            username: user.user_metadata?.username || user.email?.split('@')[0] || 'user',
-            full_name: user.user_metadata?.full_name || user.user_metadata?.name || '',
-            avatar_url: user.user_metadata?.avatar_url || null,
-            bio: null,
-            social_links: null
-          });
+        const { error: insertError } = await supabase.from('profiles').insert({
+          id: authUser.id,
+          username:
+            authUser.user_metadata?.username ||
+            authUser.email?.split('@')[0] ||
+            'user',
+          full_name:
+            authUser.user_metadata?.full_name ||
+            authUser.user_metadata?.name ||
+            '',
+          avatar_url: authUser.user_metadata?.avatar_url || null,
+          bio: null,
+          social_links: null
+        });
 
-        if (error) {
-          console.error('Error creating profile:', error);
+        if (insertError) {
+          console.error('Error creating profile:', insertError);
         }
-      } else {
-        // Update existing profile with any new metadata
-        const { error } = await supabase
-          .from('profiles')
-          .update({
-            full_name: user.user_metadata?.full_name || user.user_metadata?.name || existingProfile.full_name,
-            avatar_url: user.user_metadata?.avatar_url || existingProfile.avatar_url
-          })
-          .eq('id', user.id);
+        return;
+      }
 
-        if (error) {
-          console.error('Error updating profile:', error);
-        }
+      const { error: updateError } = await supabase
+        .from('profiles')
+        .update({
+          full_name:
+            authUser.user_metadata?.full_name ||
+            authUser.user_metadata?.name ||
+            existingProfile.full_name,
+          avatar_url:
+            authUser.user_metadata?.avatar_url || existingProfile.avatar_url
+        })
+        .eq('id', authUser.id);
+
+      if (updateError) {
+        console.error('Error updating profile:', updateError);
       }
     } catch (error) {
       console.error('Error in createOrUpdateProfile:', error);
     }
   };
 
-  const value: AuthContextType = {
+  const signUp: AuthContextValue['signUp'] = (email, password, userData) =>
+    supabase.auth.signUp({
+      email,
+      password,
+      options: { data: userData }
+    });
+
+  const signIn: AuthContextValue['signIn'] = (email, password) =>
+    supabase.auth.signInWithPassword({
+      email,
+      password
+    });
+
+  const signInWithOtp: AuthContextValue['signInWithOtp'] = (email) =>
+    supabase.auth.signInWithOtp({
+      email,
+      options: { shouldCreateUser: true }
+    });
+
+  const verifyOtp: AuthContextValue['verifyOtp'] = (email, token, type = 'email') =>
+    supabase.auth.verifyOtp({
+      email,
+      token,
+      type
+    });
+
+  const signInWithGoogle: AuthContextValue['signInWithGoogle'] = () =>
+    supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: { redirectTo: `${window.location.origin}/auth/callback` }
+    });
+
+  const signOut: AuthContextValue['signOut'] = () => supabase.auth.signOut();
+
+  const value: AuthContextValue = {
     user,
     session,
     loading,
-    signUp: auth.signUp,
-    signIn: auth.signIn,
-    signInWithOtp: auth.signInWithOtp,
-    verifyOtp: auth.verifyOtp,
-    signInWithGoogle: auth.signInWithGoogle,
-    signOut: auth.signOut,
+    signUp,
+    signIn,
+    signInWithOtp,
+    verifyOtp,
+    signInWithGoogle,
+    signOut
   };
 
-  return (
-    <AuthContext.Provider value={value}>
-      {children}
-    </AuthContext.Provider>
-  );
-};
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}
+
+export function useUser() {
+  const { user } = useAuth();
+  return user;
+}

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1,4 +1,4 @@
-import { createClient, SupabaseClient, User, Session } from '@supabase/supabase-js';
+import { createClient, type AuthChangeEvent, type AuthOtpResponse, type AuthResponse, type OAuthResponse, type Session } from '@supabase/supabase-js';
 
 // Initialize the Supabase client with environment variables
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://xgdbkqewkgwlnaaspjpe.supabase.co';
@@ -10,80 +10,64 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 // Authentication helper functions
 export const auth = {
   // Sign up with email and password
-  signUp: async (email: string, password: string, userData?: { full_name?: string; username?: string }) => {
-    const { data, error } = await supabase.auth.signUp({
+  signUp: (
+    email: string,
+    password: string,
+    userData?: { full_name?: string; username?: string }
+  ): Promise<AuthResponse> =>
+    supabase.auth.signUp({
       email,
       password,
       options: {
         data: userData
       }
-    });
-    return { data, error };
-  },
+    }),
 
   // Sign in with email and password
-  signIn: async (email: string, password: string) => {
-    const { data, error } = await supabase.auth.signInWithPassword({
+  signIn: (email: string, password: string): Promise<AuthResponse> =>
+    supabase.auth.signInWithPassword({
       email,
       password
-    });
-    return { data, error };
-  },
+    }),
 
   // Sign in with OTP
-  signInWithOtp: async (email: string) => {
-    const { data, error } = await supabase.auth.signInWithOtp({
+  signInWithOtp: (email: string): Promise<AuthOtpResponse> =>
+    supabase.auth.signInWithOtp({
       email,
       options: {
         shouldCreateUser: true
       }
-    });
-    return { data, error };
-  },
+    }),
 
   // Verify OTP
-  verifyOtp: async (email: string, token: string, type: 'signup' | 'email' = 'email') => {
-    const { data, error } = await supabase.auth.verifyOtp({
+  verifyOtp: (email: string, token: string, type: 'signup' | 'email' = 'email'): Promise<AuthResponse> =>
+    supabase.auth.verifyOtp({
       email,
       token,
       type
-    });
-    return { data, error };
-  },
+    }),
 
   // Sign in with Google
-  signInWithGoogle: async () => {
-    const { data, error } = await supabase.auth.signInWithOAuth({
+  signInWithGoogle: (): Promise<OAuthResponse> =>
+    supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
         redirectTo: `${window.location.origin}/auth/callback`
       }
-    });
-    return { data, error };
-  },
+    }),
 
   // Sign out
-  signOut: async () => {
-    const { error } = await supabase.auth.signOut();
-    return { error };
-  },
+  signOut: () => supabase.auth.signOut(),
 
   // Get current session
-  getSession: async () => {
-    const { data, error } = await supabase.auth.getSession();
-    return { data, error };
-  },
+  getSession: () => supabase.auth.getSession(),
 
   // Get current user
-  getUser: async () => {
-    const { data, error } = await supabase.auth.getUser();
-    return { data, error };
-  },
+  getUser: () => supabase.auth.getUser(),
 
   // Listen to auth changes
-  onAuthStateChange: (callback: (event: string, session: Session | null) => void) => {
-    return supabase.auth.onAuthStateChange(callback);
-  }
+  onAuthStateChange: (callback: (event: AuthChangeEvent, session: Session | null) => void) =>
+    supabase.auth.onAuthStateChange(callback)
 };
 
 // Export types for database


### PR DESCRIPTION
## Summary
- refactor the auth context to use Supabase types directly and manage profile synchronization without `any`
- update Supabase auth helpers and client consumers to avoid unused destructuring and satisfy ESLint
- clean up unused social-link state, remove dead types, and replace the feedback image preview with `next/image`

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7a32cdbf4832984061aaf415a4748