### PR TITLE
Fix feedback page image import conflict

### DIFF
--- a/src/app/feedback/page.tsx
+++ b/src/app/feedback/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useRef } from 'react';
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import AppLayout from '@/components/AppLayout';
 import AppHeader from '@/components/AppHeader';
@@ -12,6 +11,7 @@ const FeedbackPage = () => {
   const router = useRouter();
   const [feedbackText, setFeedbackText] = useState('');
   const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [selectedImage, setSelectedImage] = useState<File | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
   const [errors, setErrors] = useState<{ feedbackText?: string }>({});
@@ -37,11 +37,13 @@ const FeedbackPage = () => {
         setImagePreview(e.target?.result as string);
       };
       reader.readAsDataURL(file);
+      setSelectedImage(file);
     }
   };
 
   const removeImage = () => {
     setImagePreview(null);
+    setSelectedImage(null);
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
@@ -136,9 +138,6 @@ const FeedbackPage = () => {
               <div className="relative">
                 <Image
                   src={imagePreview}
-                  alt="Preview"
-                  width={800}
-                  height={450}
                   alt="Feedback attachment preview"
                   width={800}
                   height={512}


### PR DESCRIPTION
## Summary
- remove the duplicated Next.js Image import on the feedback page
- track the selected attachment so file details can be rendered and reset correctly
- clean up duplicated props on the Image component preview

## Testing
- npm run build *(fails: existing lint errors in auth and onboarding pages)*

------
https://chatgpt.com/codex/tasks/task_e_68da9cea0680832985be24e99182777a